### PR TITLE
Allow object

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 **tslint-react-set-state-usage** is a rule, that enforces usage of callbacks in setState calls instead of objects. Moreover, it forbids access to `this.props` and `this.state` within `setState(...)` calls.
 
 * **updater-only:** it also has updater-only option to forbid usage of second `callback` parameter of setState
+* **allow-object:** it also has allow-object option to allow objects to be passed instead of a callback
 
 ## Installation
 
@@ -31,6 +32,14 @@ To enable the **updater-only** option, rule should be used like this:
 }
 ```
 
+To enable the **allow-object** option, rule should be used like this:
+
+```JSON
+"rules:" {
+  "tslint-react-set-state-usage": [true, "allow-object"]
+}
+```
+
 ## Examples
 
 ```tsx
@@ -53,6 +62,7 @@ class NameDemo extends React.Component<{ someFlag: boolean, someCallback: () => 
   
   function onGoodClick() {
     this.setState(() => ({ name: 'goodName' })); // will not produce tslint error
+    this.setState({ name: 'goodName' }); // with allow-object option enabled, will not produce tslint error
     this.setState((state, props) => ({ redundandFlag: props.flag })); // will not produce tslint error
   }
   

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tslint-react-set-state-usage",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,33 +1,33 @@
 {
-    "name": "tslint-react-set-state-usage",
-    "version": "2.0.2",
-    "description": "TSLint rule for detection of React setState usage issues",
-    "main": "tslint.json",
-    "scripts": {
-        "build": "./node_modules/.bin/tsc -p .",
-        "test": "npm run build && \"./node_modules/.bin/tslint\" --test ./test/rules/**/tslint.json"
-    },
-    "repository": {
-        "type": "git",
-        "url": "git+https://github.com/sutrkiller/tslint-react-set-state-usage.git"
-    },
-    "keywords": [
-        "setState",
-        "tslint",
-        "rule"
-    ],
-    "author": "Tobias Kamenicky",
-    "license": "MIT",
-    "bugs": {
-        "url": "https://github.com/sutrkiller/tslint-react-set-state-usage/issues"
-    },
-    "homepage": "https://github.com/sutrkiller/tslint-react-set-state-usage#readme",
-    "dependencies": {
-        "tsutils": "^2.4.0"
-    },
-    "devDependencies": {
-        "@types/node": "^8.0.3",
-        "tslint": "^5.4.3",
-        "typescript": "2.3.4"
-    }
+  "name": "tslint-react-set-state-usage",
+  "version": "2.0.2",
+  "description": "TSLint rule for detection of React setState usage issues",
+  "main": "tslint.json",
+  "scripts": {
+    "build": "./node_modules/.bin/tsc -p .",
+    "test": "npm run build && \"./node_modules/.bin/tslint\" --test ./test/rules/**/tslint.json"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sutrkiller/tslint-react-set-state-usage.git"
+  },
+  "keywords": [
+    "setState",
+    "tslint",
+    "rule"
+  ],
+  "author": "Tobias Kamenicky",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/sutrkiller/tslint-react-set-state-usage/issues"
+  },
+  "homepage": "https://github.com/sutrkiller/tslint-react-set-state-usage#readme",
+  "dependencies": {
+    "tsutils": "^2.4.0"
+  },
+  "devDependencies": {
+    "@types/node": "^8.0.3",
+    "tslint": "^5.4.3",
+    "typescript": "2.3.4"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,33 +1,33 @@
 {
-  "name": "tslint-react-set-state-usage",
-  "version": "2.0.2",
-  "description": "TSLint rule for detection of React setState usage issues",
-  "main": "tslint.json",
-  "scripts": {
-    "build": "./node_modules/.bin/tsc -p .",
-    "test": "npm run build && \"./node_modules/.bin/tslint\" --test ./test/rules/**/tslint.json"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/sutrkiller/tslint-react-set-state-usage.git"
-  },
-  "keywords": [
-    "setState",
-    "tslint",
-    "rule"
-  ],
-  "author": "Tobias Kamenicky",
-  "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/sutrkiller/tslint-react-set-state-usage/issues"
-  },
-  "homepage": "https://github.com/sutrkiller/tslint-react-set-state-usage#readme",
-  "dependencies": {
-    "tsutils": "^2.4.0"
-  },
-  "devDependencies": {
-    "@types/node": "^8.0.3",
-    "tslint": "^5.4.3",
-    "typescript": "2.3.4"
-  }
+    "name": "tslint-react-set-state-usage",
+    "version": "2.0.2",
+    "description": "TSLint rule for detection of React setState usage issues",
+    "main": "tslint.json",
+    "scripts": {
+        "build": "./node_modules/.bin/tsc -p .",
+        "test": "npm run build && \"./node_modules/.bin/tslint\" --test ./test/rules/**/tslint.json"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/sutrkiller/tslint-react-set-state-usage.git"
+    },
+    "keywords": [
+        "setState",
+        "tslint",
+        "rule"
+    ],
+    "author": "Tobias Kamenicky",
+    "license": "MIT",
+    "bugs": {
+        "url": "https://github.com/sutrkiller/tslint-react-set-state-usage/issues"
+    },
+    "homepage": "https://github.com/sutrkiller/tslint-react-set-state-usage#readme",
+    "dependencies": {
+        "tsutils": "^2.4.0"
+    },
+    "devDependencies": {
+        "@types/node": "^8.0.3",
+        "tslint": "^5.4.3",
+        "typescript": "2.3.4"
+    }
 }

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "tslint-react-set-state-usage",
   "version": "2.0.2",
-  "description": "TSLint rule for detection non-functional setState statements",
+  "description": "TSLint rule for detection of React setState usage issues",
   "main": "tslint.json",
   "scripts": {
     "build": "./node_modules/.bin/tsc -p .",
-    "test": "npm run build && \"./node_modules/.bin/tslint\" --test test/rules/**/tslint.json"
+    "test": "npm run build && \"./node_modules/.bin/tslint\" --test ./test/rules/**/tslint.json"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tslint-react-set-state-usage",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "TSLint rule for detection of React setState usage issues",
   "main": "tslint.json",
   "scripts": {

--- a/src/rules/tslintReactSetStateUsageOptions.ts
+++ b/src/rules/tslintReactSetStateUsageOptions.ts
@@ -2,16 +2,16 @@ export const OPTION_UPDATER_ONLY = "updater-only";
 export const OPTION_ALLOW_OBJECT = "allow-object";
 
 export interface IOptions {
-  readonly updaterOnly: boolean;
-  readonly allowObject: boolean;
+    readonly updaterOnly: boolean;
+    readonly allowObject: boolean;
 }
 
 export function parseOptions(ruleArguments: any[]): IOptions {
-  const updaterOnly = ruleArguments.find((arg: any) => arg === OPTION_UPDATER_ONLY);
-  const allowObject = ruleArguments.find((arg: any) => arg === OPTION_ALLOW_OBJECT);
+    const updaterOnly = ruleArguments.find((arg: any) => arg === OPTION_UPDATER_ONLY);
+    const allowObject = ruleArguments.find((arg: any) => arg === OPTION_ALLOW_OBJECT);
 
-  return {
-    updaterOnly,
-    allowObject,
-  };
+    return {
+        updaterOnly,
+        allowObject,
+    };
 }

--- a/src/rules/tslintReactSetStateUsageOptions.ts
+++ b/src/rules/tslintReactSetStateUsageOptions.ts
@@ -1,13 +1,17 @@
 export const OPTION_UPDATER_ONLY = "updater-only";
+export const OPTION_ALLOW_OBJECT = "allow-object";
 
 export interface IOptions {
-    readonly updaterOnly: boolean;
+  readonly updaterOnly: boolean;
+  readonly allowObject: boolean;
 }
 
 export function parseOptions(ruleArguments: any[]): IOptions {
-    const updaterOnly = ruleArguments[0] as string;
+  const updaterOnly = ruleArguments.find((arg: any) => arg === OPTION_UPDATER_ONLY);
+  const allowObject = ruleArguments.find((arg: any) => arg === OPTION_ALLOW_OBJECT);
 
-    return {
-        updaterOnly: updaterOnly === OPTION_UPDATER_ONLY,
-    };
+  return {
+    updaterOnly,
+    allowObject,
+  };
 }

--- a/src/rules/tslintReactSetStateUsageRule.ts
+++ b/src/rules/tslintReactSetStateUsageRule.ts
@@ -3,16 +3,16 @@ import * as Lint from "tslint";
 import { isObjectLiteralExpression } from "tsutils";
 
 import {
-  IOptions,
-  OPTION_UPDATER_ONLY,
-  OPTION_ALLOW_OBJECT,
-  parseOptions,
+    IOptions,
+    OPTION_UPDATER_ONLY,
+    OPTION_ALLOW_OBJECT,
+    parseOptions,
 } from "./tslintReactSetStateUsageOptions";
 import {
-  getFirstSetStateAncestor,
-  isThisPropertyAccess,
-  isThisSetState,
-  removeParentheses,
+    getFirstSetStateAncestor,
+    isThisPropertyAccess,
+    isThisSetState,
+    removeParentheses,
 } from "../utils/syntaxWalkerUtils";
 
 const FAILURE_STRING = "Do not pass an object into setState. Use functional setState updater instead.";
@@ -20,70 +20,70 @@ const FAILURE_STRING_UPDATER_ONLY = `Do not use callback parameter in setState. 
 const getFailureStringForAccessedMember = (accessedMember: string) => `Do not access 'this.${accessedMember}' in setState. Use arguments from callback function instead.`;
 
 export class Rule extends Lint.Rules.AbstractRule {
-  public static metadata: Lint.IRuleMetadata = {
-    description: "Requires the setState function to be called with function as the first argument and without 'this.props' nor 'this.state' access within the function.",
-    optionExamples: [true],
-    options: {
-      items: [
-        {
-          enum: [OPTION_UPDATER_ONLY, OPTION_ALLOW_OBJECT],
-          type: "string",
+    public static metadata: Lint.IRuleMetadata = {
+        description: "Requires the setState function to be called with function as the first argument and without 'this.props' nor 'this.state' access within the function.",
+        optionExamples: [true],
+        options: {
+            items: [
+                {
+                    enum: [OPTION_UPDATER_ONLY, OPTION_ALLOW_OBJECT],
+                    type: "string",
+                },
+            ],
+            maxLength: 1,
+            minLength: 0,
+            type: "array",
         },
-      ],
-      maxLength: 1,
-      minLength: 0,
-      type: "array",
-    },
-    optionsDescription: "Not configurable.",
-    ruleName: "tslint-react-set-state-usage",
-    type: "functionality",
-    typescriptOnly: false,
-  };
+        optionsDescription: "Not configurable.",
+        ruleName: "tslint-react-set-state-usage",
+        type: "functionality",
+        typescriptOnly: false,
+    };
 
-  public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
-    const options = parseOptions(this.ruleArguments);
-    return this.applyWithFunction(sourceFile, walk, options);
-  }
+    public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
+        const options = parseOptions(this.ruleArguments);
+        return this.applyWithFunction(sourceFile, walk, options);
+    }
 }
 
 function walk(ctx: Lint.WalkContext<IOptions>) {
-  const { sourceFile, options: { updaterOnly, allowObject } } = ctx;
+    const { sourceFile, options: { updaterOnly, allowObject } } = ctx;
 
-  function cb(node: ts.Node): void {
-    if (isThisSetState(node)) {
-      inspectSetStateCall(node, ctx, updaterOnly, allowObject);
+    function cb(node: ts.Node): void {
+        if (isThisSetState(node)) {
+            inspectSetStateCall(node, ctx, updaterOnly, allowObject);
+        }
+        else if (isThisState(node) || isThisProps(node)) {
+            inspectThisPropsOrStateContext(node, ctx);
+        }
+
+        return ts.forEachChild(node, cb);
     }
-    else if (isThisState(node) || isThisProps(node)) {
-      inspectThisPropsOrStateContext(node, ctx);
-    }
 
-    return ts.forEachChild(node, cb);
-  }
-
-  return ts.forEachChild(sourceFile, cb);
+    return ts.forEachChild(sourceFile, cb);
 }
 
 function inspectSetStateCall(node: ts.CallExpression, ctx: Lint.WalkContext<IOptions>, updaterOnly: boolean, allowObject: boolean) {
-  const { 0: updaterArgument, 1: callbackArgument, length: argumentsCount } = node.arguments;
+    const { 0: updaterArgument, 1: callbackArgument, length: argumentsCount } = node.arguments;
 
-  // Forbid object literal
-  const bareUpdaterArgument = removeParentheses(updaterArgument);
-  if (!allowObject && isObjectLiteralExpression(bareUpdaterArgument)) {
-    ctx.addFailureAtNode(updaterArgument, FAILURE_STRING);
-  }
+    // Forbid object literal
+    const bareUpdaterArgument = removeParentheses(updaterArgument);
+    if (!allowObject && isObjectLiteralExpression(bareUpdaterArgument)) {
+        ctx.addFailureAtNode(updaterArgument, FAILURE_STRING);
+    }
 
-  // Forbid second argument if updaterOnly flag set
-  if (updaterOnly && argumentsCount > 1) {
-    ctx.addFailureAtNode(callbackArgument, FAILURE_STRING_UPDATER_ONLY);
-  }
+    // Forbid second argument if updaterOnly flag set
+    if (updaterOnly && argumentsCount > 1) {
+        ctx.addFailureAtNode(callbackArgument, FAILURE_STRING_UPDATER_ONLY);
+    }
 }
 
 function inspectThisPropsOrStateContext(node: ts.PropertyAccessExpression, ctx: Lint.WalkContext<IOptions>) {
-  const setStateCall = getFirstSetStateAncestor(node.parent);
+    const setStateCall = getFirstSetStateAncestor(node.parent);
 
-  if (setStateCall) {
-    ctx.addFailureAtNode(node, getFailureStringForAccessedMember(node.name.text));
-  }
+    if (setStateCall) {
+        ctx.addFailureAtNode(node, getFailureStringForAccessedMember(node.name.text));
+    }
 }
 
 const isThisState = (node: ts.Node): node is ts.PropertyAccessExpression => isThisPropertyAccess(node) && node.name.text === "state";

--- a/src/rules/tslintReactSetStateUsageRule.ts
+++ b/src/rules/tslintReactSetStateUsageRule.ts
@@ -3,15 +3,16 @@ import * as Lint from "tslint";
 import { isObjectLiteralExpression } from "tsutils";
 
 import {
-    IOptions,
-    OPTION_UPDATER_ONLY,
-    parseOptions,
+  IOptions,
+  OPTION_UPDATER_ONLY,
+  OPTION_ALLOW_OBJECT,
+  parseOptions,
 } from "./tslintReactSetStateUsageOptions";
 import {
-    getFirstSetStateAncestor,
-    isThisPropertyAccess,
-    isThisSetState,
-    removeParentheses,
+  getFirstSetStateAncestor,
+  isThisPropertyAccess,
+  isThisSetState,
+  removeParentheses,
 } from "../utils/syntaxWalkerUtils";
 
 const FAILURE_STRING = "Do not pass an object into setState. Use functional setState updater instead.";
@@ -19,70 +20,70 @@ const FAILURE_STRING_UPDATER_ONLY = `Do not use callback parameter in setState. 
 const getFailureStringForAccessedMember = (accessedMember: string) => `Do not access 'this.${accessedMember}' in setState. Use arguments from callback function instead.`;
 
 export class Rule extends Lint.Rules.AbstractRule {
-    public static metadata: Lint.IRuleMetadata = {
-        description: "Requires the setState function to be called with function as the first argument and without 'this.props' nor 'this.state' access within the function.",
-        optionExamples: [true],
-        options: {
-            items: [
-                {
-                    enum: [OPTION_UPDATER_ONLY],
-                    type: "string",
-                },
-            ],
-            maxLength: 1,
-            minLength: 0,
-            type: "array",
+  public static metadata: Lint.IRuleMetadata = {
+    description: "Requires the setState function to be called with function as the first argument and without 'this.props' nor 'this.state' access within the function.",
+    optionExamples: [true],
+    options: {
+      items: [
+        {
+          enum: [OPTION_UPDATER_ONLY, OPTION_ALLOW_OBJECT],
+          type: "string",
         },
-        optionsDescription: "Not configurable.",
-        ruleName: "tslint-react-set-state-usage",
-        type: "functionality",
-        typescriptOnly: false,
-    };
+      ],
+      maxLength: 1,
+      minLength: 0,
+      type: "array",
+    },
+    optionsDescription: "Not configurable.",
+    ruleName: "tslint-react-set-state-usage",
+    type: "functionality",
+    typescriptOnly: false,
+  };
 
-    public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
-        const options = parseOptions(this.ruleArguments);
-        return this.applyWithFunction(sourceFile, walk, options);
-    }
+  public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
+    const options = parseOptions(this.ruleArguments);
+    return this.applyWithFunction(sourceFile, walk, options);
+  }
 }
 
 function walk(ctx: Lint.WalkContext<IOptions>) {
-    const { sourceFile, options: { updaterOnly } } = ctx;
+  const { sourceFile, options: { updaterOnly, allowObject } } = ctx;
 
-    function cb(node: ts.Node): void {
-        if (isThisSetState(node)) {
-            inspectSetStateCall(node, ctx, updaterOnly);
-        }
-        else if (isThisState(node) || isThisProps(node)) {
-            inspectThisPropsOrStateContext(node, ctx);
-        }
-
-        return ts.forEachChild(node, cb);
+  function cb(node: ts.Node): void {
+    if (isThisSetState(node)) {
+      inspectSetStateCall(node, ctx, updaterOnly, allowObject);
+    }
+    else if (isThisState(node) || isThisProps(node)) {
+      inspectThisPropsOrStateContext(node, ctx);
     }
 
-    return ts.forEachChild(sourceFile, cb);
+    return ts.forEachChild(node, cb);
+  }
+
+  return ts.forEachChild(sourceFile, cb);
 }
 
-function inspectSetStateCall(node: ts.CallExpression, ctx: Lint.WalkContext<IOptions>, updaterOnly: boolean) {
-    const { 0: updaterArgument, 1: callbackArgument, length: argumentsCount } = node.arguments;
+function inspectSetStateCall(node: ts.CallExpression, ctx: Lint.WalkContext<IOptions>, updaterOnly: boolean, allowObject: boolean) {
+  const { 0: updaterArgument, 1: callbackArgument, length: argumentsCount } = node.arguments;
 
-    // Forbid object literal
-    const bareUpdaterArgument = removeParentheses(updaterArgument);
-    if (isObjectLiteralExpression(bareUpdaterArgument)) {
-        ctx.addFailureAtNode(updaterArgument, FAILURE_STRING);
-    }
+  // Forbid object literal
+  const bareUpdaterArgument = removeParentheses(updaterArgument);
+  if (!allowObject && isObjectLiteralExpression(bareUpdaterArgument)) {
+    ctx.addFailureAtNode(updaterArgument, FAILURE_STRING);
+  }
 
-    // Forbid second argument if updaterOnly flag set
-    if (updaterOnly && argumentsCount > 1) {
-        ctx.addFailureAtNode(callbackArgument, FAILURE_STRING_UPDATER_ONLY);
-    }
+  // Forbid second argument if updaterOnly flag set
+  if (updaterOnly && argumentsCount > 1) {
+    ctx.addFailureAtNode(callbackArgument, FAILURE_STRING_UPDATER_ONLY);
+  }
 }
 
 function inspectThisPropsOrStateContext(node: ts.PropertyAccessExpression, ctx: Lint.WalkContext<IOptions>) {
-    const setStateCall = getFirstSetStateAncestor(node.parent);
+  const setStateCall = getFirstSetStateAncestor(node.parent);
 
-    if (setStateCall) {
-        ctx.addFailureAtNode(node, getFailureStringForAccessedMember(node.name.text));
-    }
+  if (setStateCall) {
+    ctx.addFailureAtNode(node, getFailureStringForAccessedMember(node.name.text));
+  }
 }
 
 const isThisState = (node: ts.Node): node is ts.PropertyAccessExpression => isThisPropertyAccess(node) && node.name.text === "state";

--- a/test/rules/tslint-react-set-state-usage/allowObject/test.ts.lint
+++ b/test/rules/tslint-react-set-state-usage/allowObject/test.ts.lint
@@ -1,0 +1,30 @@
+this.setState({obj: 123});
+this.setState({obj: 123}, () => "callback");
+
+this.setState((_) => ({obj: 123}));
+this.setState((prevState) => ({obj: prevState.obj}));
+this.setState((prevState, props) => ({obj: prevState.obj, prop: props.obj}));
+this.setState((_, props) => ({prop: props.obj}));
+
+this.setState((_) => ({obj: 123}), () => "callback");
+this.setState((prevState) => ({obj: prevState.obj}), () => "callback");
+this.setState((prevState, props) => ({obj: prevState.obj, prop: props.obj}), () => "callback");
+this.setState((_, props) => ({prop: props.obj}), () => "callback");
+
+this.setState((_) => ({obj: 123, prop: this.props.doNotAccessMeInSetState}));
+                                       ~~~~~~~~~~  [Do not access 'this.props' in setState. Use arguments from callback function instead.]
+
+this.setState((_) => ({obj: 123, prop: this.state.doNotAccessMeInSetState}));
+                                       ~~~~~~~~~~  [Do not access 'this.state' in setState. Use arguments from callback function instead.]
+
+this.setState((_) => ({obj: 123, prop: this.props.doNotAccessMeInSetState, state: this.state.doNotAccessMeInSetState}));
+                                       ~~~~~~~~~~  [Do not access 'this.props' in setState. Use arguments from callback function instead.]
+                                                                                  ~~~~~~~~~~  [Do not access 'this.state' in setState. Use arguments from callback function instead.]
+
+this.setState(({obj: 123, prop: this.props.doNotAccessMeInSetState, state: this.state.doNotAccessMeInSetState})));
+                                ~~~~~~~~~~  [Do not access 'this.props' in setState. Use arguments from callback function instead.]
+                                                                           ~~~~~~~~~~  [Do not access 'this.state' in setState. Use arguments from callback function instead.]
+
+this.setState(((({obj: 123, prop: this.props.doNotAccessMeInSetState, state: this.state.doNotAccessMeInSetState})))));
+                                  ~~~~~~~~~~  [Do not access 'this.props' in setState. Use arguments from callback function instead.]
+                                                                             ~~~~~~~~~~  [Do not access 'this.state' in setState. Use arguments from callback function instead.]

--- a/test/rules/tslint-react-set-state-usage/allowObject/tslint.json
+++ b/test/rules/tslint-react-set-state-usage/allowObject/tslint.json
@@ -1,0 +1,9 @@
+{
+  "rulesDirectory": "../../../../src/rules",
+  "rules": {
+    "tslint-react-set-state-usage": [
+      true,
+      "allow-object"
+    ]
+  }
+}

--- a/tslint.json
+++ b/tslint.json
@@ -2,8 +2,11 @@
   "defaultSeverity": "error",
   "jsRules": {},
   "rules": {
-    "tslint-react-set-state-usage": true
-      },
+    "tslint-react-set-state-usage": [
+      true,
+      "allow-object"
+    ]
+  },
   "rulesDirectory": [
     "src/rules"
   ]

--- a/tslint.json
+++ b/tslint.json
@@ -1,10 +1,10 @@
 {
-    "defaultSeverity": "error",
-    "jsRules": {},
-    "rules": {
-        "tslint-react-set-state-usage": true
-    },
-    "rulesDirectory": [
-        "src/rules"
-    ]
+  "defaultSeverity": "error",
+  "jsRules": {},
+  "rules": {
+    "tslint-react-set-state-usage": true
+  },
+  "rulesDirectory": [
+    "src/rules"
+  ]
 }

--- a/tslint.json
+++ b/tslint.json
@@ -1,13 +1,10 @@
 {
-  "defaultSeverity": "error",
-  "jsRules": {},
-  "rules": {
-    "tslint-react-set-state-usage": [
-      true,
-      "allow-object"
+    "defaultSeverity": "error",
+    "jsRules": {},
+    "rules": {
+        "tslint-react-set-state-usage": true
+    },
+    "rulesDirectory": [
+        "src/rules"
     ]
-  },
-  "rulesDirectory": [
-    "src/rules"
-  ]
 }


### PR DESCRIPTION
I've created a fork with a new "allow-object" option to allow objects to be passed to setState. It still reports the usage of 'this.state' and 'this.props' in setState. This is in line with the React documentation: https://reactjs.org/docs/state-and-lifecycle.html#state-updates-may-be-asynchronous.